### PR TITLE
:bug: file input only allows only single files

### DIFF
--- a/app/screen/toolbar/fileopen.js
+++ b/app/screen/toolbar/fileopen.js
@@ -12,7 +12,7 @@ export default class Fileopen extends React.Component {
     return (
       <div className="tool-fileopen">
       <label htmlFor="input-file" className="input-label">
-        <input type="file" className="input-file"
+        <input type="file" className="input-file" multiple
             id="input-file" name="input-file"  accept="image/*"
             onChange={this.onChange.bind(this)}
             />


### PR DESCRIPTION
The input element only allowed a single file to be chosen and uploaded. This fixes it, so a sprite with more than one file can be generated ;)